### PR TITLE
Bitsintjacobi2

### DIFF
--- a/src/Combinatorics.jl
+++ b/src/Combinatorics.jl
@@ -87,6 +87,26 @@ function jacobisymbol(a::Integer, b::Integer)
         (Ptr{BigInt}, Ptr{BigInt}), &ba, &bb)
 end
 
+# Taken from perl Math::Prime::Util
+function jacobisymbol(in::Union(Signed,Unsigned),m::Union(Signed,Unsigned))
+    j = 1
+    n = in < 0 ? -in : in
+    if m <= 0 || (m%2) == 0 return 0 end
+    if (in < 0 && (m%4) == 3) j = -j end
+    while (n != 0)
+        while ((n % 2) == 0)
+            n >>= 1
+            if  (m % 8) == 3 || (m % 8) == 5  j = -j end
+        end
+        t = n; n = m; m = t
+        if (n % 4) == 3 && (m % 4) == 3  j = -j end
+        n = n % m
+    end
+    return (m == 1) ? j : 0
+end
+
+legendresymbol(n::Union(Signed,Unsigned),m::Union(Signed,Unsigned)) = jacobisymbol(n,m)
+
 #Computes Lassalle's sequence
 #OEIS entry A180874
 function lassalle(m::Integer)

--- a/test/basic.jl
+++ b/test/basic.jl
@@ -22,6 +22,10 @@
 # legendresymbol
 @test legendresymbol(1001,9907) == jacobisymbol(1001,9907) == -1
 
+for (n,m) in ( (1001,9907), (10,7), (1,1), (typemax(Int64)-4, typemax(Int64)-6))
+    @test jacobisymbol(n,m) == jacobisymbol(BigInt(n),BigInt(m))
+end
+
 # lucas
 @test lucas(10) == 123
 @test lucas(100) == BigInt("792070839848372253127")


### PR DESCRIPTION
Hi, You may be interested in this as well.
This is the jacobi symbol for Int64, Int32, etc. I compared it to the existing code and it is faster in all cases that I tried (very large numbers, small numbers) by as much as a factor of 2. It is much slower than the call to gmp if the input types are  allowed to be BigInt.

--John
