### PR TITLE
0.4 compatibility

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -1,3 +1,3 @@
-julia 0.3
+julia 0.3+
 Compat
-Polynomial
+Polynomials

--- a/src/Combinatorics.jl
+++ b/src/Combinatorics.jl
@@ -1,6 +1,6 @@
 module Combinatorics
 
-using Compat, Polynomial
+using Compat, Polynomials
 
 export  bell,
         catalan,
@@ -50,7 +50,7 @@ function catalan(bn::Integer)
     div(binomial(2*n, n), (n + 1))
 end
 
-# The number of permutations of n with no fixed points (subfactorial) 
+# The number of permutations of n with no fixed points (subfactorial)
 function derangement(sn::Integer)
     n = BigInt(sn)
     return num(factorial(n)*sum([(-1)^k//factorial(k) for k=0:n]))

--- a/src/Combinatorics.jl
+++ b/src/Combinatorics.jl
@@ -62,7 +62,7 @@ function doublefactorial(n::Integer)
     end
     z = BigInt()
     ccall((:__gmpz_2fac_ui, :libgmp), Void,
-        (Ptr{BigInt}, UInt), &z, UInt(n))
+        (Ptr{BigInt}, UInt), &z, @compat(UInt(n)))
     return z
 end
 
@@ -72,7 +72,7 @@ function fibonacci(n::Integer)
     end
     z = BigInt()
     ccall((:__gmpz_fib_ui, :libgmp), Void,
-        (Ptr{BigInt}, UInt), &z, UInt(n))
+        (Ptr{BigInt}, UInt), &z, @compat(UInt(n)))
     return z
 end
 
@@ -109,7 +109,7 @@ function lucas(n::Integer)
     end
     z = BigInt()
     ccall((:__gmpz_lucnum_ui, :libgmp), Void,
-        (Ptr{BigInt}, UInt), &z, UInt(n))
+        (Ptr{BigInt}, UInt), &z, @compat(UInt(n)))
     return z
 end
 
@@ -119,7 +119,7 @@ function multifactorial(n::Integer, m::Integer)
     end
     z = BigInt()
     ccall((:__gmpz_mfac_uiui, :libgmp), Void,
-        (Ptr{BigInt}, UInt, UInt), &z, UInt(n), UInt(m))
+        (Ptr{BigInt}, UInt, UInt), &z, @compat(UInt(n)), @compat(UInt(m)))
     return z
 end
 
@@ -140,7 +140,7 @@ function primorial(n::Integer)
     end
     z = BigInt()
     ccall((:__gmpz_primorial_ui, :libgmp), Void,
-        (Ptr{BigInt}, UInt), &z, UInt(n))
+        (Ptr{BigInt}, UInt), &z, @compat(UInt(n)))
     return z
 end
 

--- a/src/Combinatorics.jl
+++ b/src/Combinatorics.jl
@@ -3,7 +3,6 @@ module Combinatorics
 using Compat, Polynomials
 
 export  bell,
-        catalan,
         derangement,
         doublefactorial,
         fibonacci,
@@ -63,7 +62,7 @@ function doublefactorial(n::Integer)
     end
     z = BigInt()
     ccall((:__gmpz_2fac_ui, :libgmp), Void,
-        (Ptr{BigInt}, Uint), &z, uint(n))
+        (Ptr{BigInt}, UInt), &z, UInt(n))
     return z
 end
 
@@ -73,7 +72,7 @@ function fibonacci(n::Integer)
     end
     z = BigInt()
     ccall((:__gmpz_fib_ui, :libgmp), Void,
-        (Ptr{BigInt}, Uint), &z, uint(n))
+        (Ptr{BigInt}, UInt), &z, UInt(n))
     return z
 end
 
@@ -110,7 +109,7 @@ function lucas(n::Integer)
     end
     z = BigInt()
     ccall((:__gmpz_lucnum_ui, :libgmp), Void,
-        (Ptr{BigInt}, Uint), &z, uint(n))
+        (Ptr{BigInt}, UInt), &z, UInt(n))
     return z
 end
 
@@ -120,7 +119,7 @@ function multifactorial(n::Integer, m::Integer)
     end
     z = BigInt()
     ccall((:__gmpz_mfac_uiui, :libgmp), Void,
-        (Ptr{BigInt}, Uint, Uint), &z, uint(n), uint(m))
+        (Ptr{BigInt}, UInt, UInt), &z, UInt(n), UInt(m))
     return z
 end
 
@@ -141,7 +140,7 @@ function primorial(n::Integer)
     end
     z = BigInt()
     ccall((:__gmpz_primorial_ui, :libgmp), Void,
-        (Ptr{BigInt}, Uint), &z, uint(n))
+        (Ptr{BigInt}, UInt), &z, UInt(n))
     return z
 end
 

--- a/src/partitions.jl
+++ b/src/partitions.jl
@@ -15,9 +15,9 @@ function integer_partitions(n::Integer)
     list = Vector{Int}[]
 
     for p in integer_partitions(n-1)
-        push!(list, [p, 1])
+        push!(list, [p; 1])
         if length(p) == 1 || p[end] < p[end-1]
-            push!(list, [p[1:end-1], p[end]+1])
+            push!(list, [p[1:end-1]; p[end]+1])
         end
     end
 
@@ -95,4 +95,3 @@ function ncpart(a::Integer, b::Integer, nn::Integer,
     end
   end
 end
-

--- a/src/youngdiagrams.jl
+++ b/src/youngdiagrams.jl
@@ -4,11 +4,11 @@
 
 typealias Partition Vector{Int64}
 typealias YoungDiagram Array{Int64,2}
-typealias SkewDiagram (Partition, Partition)
+typealias SkewDiagram @compat(Tuple{Partition,Partition})
 
-export Partition,    
+export Partition,
        YoungDiagram, #represents shape of Young diagram
-       SkewDiagram,  #skew diagrams 
+       SkewDiagram,  #skew diagrams
        partitionsequence,
        isrimhook,    #Check if skew diagram is rim hook
        leglength,
@@ -158,5 +158,3 @@ function character(λ::Partition, μ::Partition)
     Λ▔ = partitionsequence(λ)
     MN1inner(Λ▔, T, μ, 1)
 end
-
-

--- a/test/basic.jl
+++ b/test/basic.jl
@@ -1,30 +1,30 @@
 # catalan
-@test catalan(5) == 42
-@test catalan(30) == BigInt("3814986502092304")
+@test Combinatorics.catalan(5) == 42
+@test Combinatorics.catalan(30) == parse(BigInt,"3814986502092304")
 
 # derangement
 @test derangement(4) == 9
-@test derangement(24) == BigInt("228250211305338670494289")
+@test derangement(24) == parse(BigInt,"228250211305338670494289")
 
 # doublefactorial
-@test doublefactorial(70) == BigInt("355044260642859198243475901411974413130137600000000")
+@test doublefactorial(70) == parse(BigInt,"355044260642859198243475901411974413130137600000000")
 
 # fibonacci
 @test fibonacci(5) == 5
-@test fibonacci(101) == BigInt("573147844013817084101")
+@test fibonacci(101) == parse(BigInt,"573147844013817084101")
 
 # hyperfactorial
-@test hyperfactorial(8) == BigInt("55696437941726556979200000")
+@test hyperfactorial(8) == parse(BigInt,"55696437941726556979200000")
 
 # lassalle
-@test lassalle(14) == BigInt("270316008395632253340")
+@test lassalle(14) == parse(BigInt,"270316008395632253340")
 
 # legendresymbol
 @test legendresymbol(1001,9907) == jacobisymbol(1001,9907) == -1
 
 # lucas
 @test lucas(10) == 123
-@test lucas(100) == BigInt("792070839848372253127")
+@test lucas(100) == parse(BigInt,"792070839848372253127")
 
 # multifactorial
 @test multifactorial(40,2) == doublefactorial(40)
@@ -40,10 +40,9 @@
 
 # bell
 @test bell(7) == 877
-@test bell(42) == BigInt("35742549198872617291353508656626642567")
+@test bell(42) == parse(BigInt,"35742549198872617291353508656626642567")
 @test_throws DomainError bell(-1)
 
 # integer_partitions
 @test integer_partitions(5) == Any[[1, 1, 1, 1, 1], [2, 1, 1, 1], [2, 2, 1], [3, 1, 1], [3, 2], [4, 1], [5]]
 @test_throws DomainError integer_partitions(-1)
-

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,5 +1,6 @@
 using Combinatorics
 using Base.Test
+using Compat
 include("basic.jl")
 include("youngdiagrams.jl")
 


### PR DESCRIPTION
This restores 0.4 compatibility.  It also uses Polynomials instead of Polynomial.  It no longer exports catalan to avoid conflict with Base.catalan.

Next up: RandomMatrices.jl!